### PR TITLE
Fix minimum ansible version

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   company: SinglePlatform (http://www.singleplatform.com/)
   license: BSD 3-Clause
 
-  min_ansible_version: 2.1
+  min_ansible_version: 2.4
   platforms:
     - name: Ubuntu
       versions:


### PR DESCRIPTION
Because `include_tasks` was introduced in 2.4

https://docs.ansible.com/ansible/2.4/include_tasks_module.html